### PR TITLE
Fixing issue when downloading .html files

### DIFF
--- a/Chapter03/01_web_spider/utilities.js
+++ b/Chapter03/01_web_spider/utilities.js
@@ -11,7 +11,7 @@ module.exports.urlToFilename = function urlToFilename(url) {
       return component !== '';
     })
     .map(function(component) {
-      return slug(component);
+      return slug(component, { remove: null });
     })
     .join('/');
   let filename = path.join(parsedUrl.hostname, urlPath);


### PR DESCRIPTION
I faced an issue while playing around with Web spider example in chapter 3
```bash
$ node index.js http://www.example.com/index.html
Downloading http://www.example.com/index.html
Completed the download of "www.example.com/indexhtml.html"
```

The correct file name should be `index.html` not `indexhtml.html`

According to slug [docs](https://github.com/dodo/node-slug#options) the default behavior is removing the dots from the string, so we must provide options with `{ remove: null }` to get the following result.

```bash
$ node index.js http://www.example.com/index.html
Downloading http://www.example.com/index.html
Completed the download of "www.example.com/index.html"
```