### PR TITLE
ch02-07- change to async try catch

### DIFF
--- a/Chapter02/07_callback_propagating_errors/readJSON.js
+++ b/Chapter02/07_callback_propagating_errors/readJSON.js
@@ -28,5 +28,7 @@ let cb = (err, data) => {
   console.log(data)
 };
 
-readJSON('valid_json.json', cb); // dumps the content
-readJSON('invalid_json.json', cb); // prints error (SyntaxError)
+readJSON('valid_json.json',(err, data) => {
+  cb(err, data);
+  readJSON('invalid_json.json', cb); // prints error (SyntaxError)
+}); // dumps the content


### PR DESCRIPTION
The example talks about async read file and try catch, but the call to the function is sync.
I changed and now the example works as should: reads valid json and prints error with invalid json